### PR TITLE
auto converting data table in console table

### DIFF
--- a/R/handlers.R
+++ b/R/handlers.R
@@ -89,6 +89,7 @@ console_log <- function(message, expand = FALSE) {
 #'
 #' Outputs an data object to the browser's console in table format
 #' @param data an object to display in the browser (data.frame, etc.)
+#' @param to_json an optional argument that transforms input data to json
 #' @return Outputs an object to the browser's console
 #' @keywords browsertools, debugging, console
 #' @examples
@@ -96,8 +97,13 @@ console_log <- function(message, expand = FALSE) {
 #' @importFrom shiny getDefaultReactiveDomain
 #' @references \url{https://developer.mozilla.org/en-US/docs/Web/API/Console/table}
 #' @export
-console_table <- function(data) {
+console_table <- function(data, to_json = TRUE) {
+
+    # validate
     if (is.null(data)) stop("argument 'data' is undefined")
+    if (to_json) data <- as_js_object(data)
+
+    # send
     session <- getDefaultReactiveDomain()
     session$sendCustomMessage("console_table", data)
 }

--- a/man/console_table.Rd
+++ b/man/console_table.Rd
@@ -4,10 +4,12 @@
 \alias{console_table}
 \title{\code{console_table}}
 \usage{
-console_table(data)
+console_table(data, to_json = TRUE)
 }
 \arguments{
 \item{data}{an object to display in the browser (data.frame, etc.)}
+
+\item{to_json}{an optional argument that transforms input data to json}
 }
 \value{
 Outputs an object to the browser's console


### PR DESCRIPTION
This merge includes a small improvement to the function `console_table`. Previously, it was recommended to run `as_json_object` on the desired object prior to passing it into `console_table`. This was a bit sloppy as it required an additional step and extra objects in the namespace. This update adds the function `as_json_object` into the `console_table` function. I also added the option `to_json`, which controls if the input data should be converted. It may be useful to run `to_json = FALSE` in situations where you are working with lists or other data structures. 